### PR TITLE
fix: Create lambda function to wait for data-hidden='false'

### DIFF
--- a/app/scrape.py
+++ b/app/scrape.py
@@ -115,6 +115,12 @@ def scrape_job_descriptions(job_title, location, limit=45):
                     current_job = len(job_descriptions) + 1
                     logger.info(f"Processing job {current_job}...")
                     link.click()
+                    wait.until(
+                        lambda browser: browser.find_element(
+                            By.CSS_SELECTOR,
+                            ".jdv-content[data-hidden='false']"
+                        )
+                    )
                     description = wait.until(
                         EC.presence_of_element_located((By.CLASS_NAME, "job-description-container"))
                     )
@@ -142,4 +148,3 @@ def scrape_job_descriptions(job_title, location, limit=45):
     finally:
         logger.info("Closing browser...")
         browser.quit()
-        


### PR DESCRIPTION
Targeting and waiting for "job-description-container" to load was not giving enough time for the job descriptions to load. by targeting and waiting for `<div class="jdv-content" data-hidden="true"` to switch to `<div class="jdv-content" data-hidden="false"` after the job link is clicked assures that the `job-description-continer` is properly loaded and available for scraping.