### PR TITLE
adds more robust add dismissal measures

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -61,7 +61,7 @@ def scrape_jobs():
     job_title = request.form.get("job_title")
     location = request.form.get("location")
     
-    job_descriptions = scrape_job_descriptions(job_title, location, limit=10)
+    job_descriptions = scrape_job_descriptions(job_title, location, limit=100)
     keywords_dict = extract_total_keywords(job_descriptions)
 
     session["keywords_data"] = keywords_dict


### PR DESCRIPTION
- modifies `dismiss_ads()` function to also handle iFrames, ad containers and any overlays that might pop up
- calls the `dismiss_ads()` function before clicking on the job description links
- sets the default function limit to 100