### PR TITLE
pushes footer to bottom of page when there isn't enough content to do so

### DIFF
--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -10,3 +10,7 @@
 #alert-close {
     float: right;
 }
+
+.main-content {
+    min-height: calc(100dvh - 327px);
+}

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -70,7 +70,7 @@
                 </header>
             {% endif %}
         {% endwith %}
-		<main class="container mt-5 py-5 text-center">
+		<main class="main-content container mt-5 py-5 text-center">
             {% block main %}{% endblock %}
         </main>
 		<footer class="py-3 my-4">


### PR DESCRIPTION
- Adds a `.main-content` class to the main element
- Calculates the min-height for the main content container minus the header height, footer height, and the padding of the main content container