### PR TITLE
No results handling and form validation

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -68,9 +68,16 @@ def charts():
 
 @app.route("/scrape", methods=["POST"])
 def scrape_jobs():
-    # TODO: add form validation
     job_title = request.form.get("job_title")
     location = request.form.get("location")
+
+    if not job_title:
+        flash("Please enter a job title", "error")
+        return redirect("/")
+    
+    if not location:
+        flash("Please enter a location", "error")
+        return redirect("/")
     
     job_descriptions = scrape_job_descriptions(job_title, location, limit=50)
     if job_descriptions == []:

--- a/app/app.py
+++ b/app/app.py
@@ -73,7 +73,10 @@ def scrape_jobs():
     location = request.form.get("location")
     
     job_descriptions = scrape_job_descriptions(job_title, location, limit=50)
-    keywords_dict = extract_total_keywords(job_descriptions)
+    if job_descriptions == []:
+        return render_template("no-results.html")
+    else:
+        keywords_dict = extract_total_keywords(job_descriptions)
 
     session["keywords_data"] = keywords_dict
     session_data = session["keywords_data"]

--- a/app/extract.py
+++ b/app/extract.py
@@ -21,9 +21,12 @@ def find_keywords(keywords, description):
 
 def extract_total_keywords(jobs_list: JobsList) -> Dict[str, int]:
     total_keywords = {}
-    for job in jobs_list[0]["descriptions"]:
-        found_keywords = find_keywords(keywords_set, job["description"])
-        for keyword in found_keywords:
-            total_keywords[keyword] = total_keywords.get(keyword, 0) + 1
+    if not jobs_list:
+        return {}
+    else:
+        for job in jobs_list[0]["descriptions"]:
+            found_keywords = find_keywords(keywords_set, job["description"])
+            for keyword in found_keywords:
+                total_keywords[keyword] = total_keywords.get(keyword, 0) + 1
 
-    return total_keywords
+        return total_keywords

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -52,7 +52,7 @@
                         <!-- container for loading text and loader animation -->
                         <div id="loading-container" hidden="">
                             <p>Searching job descriptions...</p>
-                            <p>Typically takes one minute to complete</p>
+                            <p>Can take up to one minute to complete</p>
                             <div class="lds-ellipsis"><div></div><div></div><div></div><div></div></div>
                         </div>
                 

--- a/app/templates/no-results.html
+++ b/app/templates/no-results.html
@@ -1,0 +1,15 @@
+{% extends "layout.html" %}
+
+{% block title %} 
+    No Results
+{% endblock %}
+
+{% block main %}
+    <h1>No Results</h1>
+    <p>Your search turned up no results. Please try again.</p>
+    <h2>
+        <a href="/">
+            Home
+        </a>
+    </h2>
+{% endblock %}


### PR DESCRIPTION
adds logic to handle no results being returned from a search and form validation for job title and location fields.

- if either job title or location is left empty, a message is flashed and user is redirected right back to the home "search" page
- adds a check in Flask `/scrape` route to see if `job_descriptions` is an empty list. If so, the program renders `no-results.html`
- adds a check in `extract_total_keywords()` to see if `jobs_list` object passed in is empty. If so, returns an empty dict
-  creates `no-results.html` to be redirected to when `job_descriptions == []`