### PR TITLE
Chore/cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Science course by Harvard.
 
 Inspired by what I wish would have existed when I was starting my journey into
 software engineering, I created SkillSift. It's a web app that takes a users job
-title and location then scrapes their local job boards, returning a list and
+title and location then searches their local job boards, returning a list and
 graphs of the most sought after tech skills for their locale.
 
 Reverse engineering the job search and first starting with what skills and knowledge

--- a/app/app.py
+++ b/app/app.py
@@ -114,4 +114,4 @@ def scrape_jobs():
 
 
 if __name__ == "__main__":
-    app.run(debug=True)
+    app.run()

--- a/app/app.py
+++ b/app/app.py
@@ -68,7 +68,6 @@ def charts():
                            chart_data=chart_data)
 
 
-# TODO: create 'About' route
 @app.route("/about")
 def about():
     return render_template("about.html",
@@ -91,13 +90,16 @@ def scrape_jobs():
     session["job_title"] = job_title
     session["location"] = location
     
-    job_descriptions = scrape_job_descriptions(job_title, location, limit=20)
+    job_descriptions = scrape_job_descriptions(job_title, location, limit=50)
     if job_descriptions == []:
         return render_template("no-results.html",
                                job_title=job_title,
                                location=location,)
     else:
         keywords_dict = extract_total_keywords(job_descriptions)
+        if keywords_dict == {}:
+            return render_template("no-keywords.html", job_title=job_title)
+    
 
     session["num_of_jobs"] = job_descriptions[0]["descriptions"][-1]["index"]
     session["keywords_data"] = keywords_dict

--- a/app/app.py
+++ b/app/app.py
@@ -106,6 +106,7 @@ def scrape_jobs():
 
     sorted_keywords_dict = dict(sorted(session["keywords_data"].items(), key=lambda item: item[1], reverse=True))
     return render_template("list.html",
+                           current_page="list",
                            job_title=job_title,
                            location=location,
                            num_of_jobs = session["num_of_jobs"],

--- a/app/templates/no-keywords.html
+++ b/app/templates/no-keywords.html
@@ -1,0 +1,20 @@
+{% extends "layout.html" %}
+
+{% block title %} 
+    No Keywords
+{% endblock %}
+
+{% block main %}
+    <h1>No Results</h1>
+    <p>
+        No technical keywords found in descriptions for {{ job_title }}s.
+    </p>
+    <p>
+        Please try searching again for a different job title.
+    </p>
+    <h2>
+        <a href="/">
+            Home
+        </a>
+    </h2>
+{% endblock %}


### PR DESCRIPTION
This PR incorporates a few small housekeeping changes such as:
- BUGFIX: adding a check for an empty dictionary being returned, thus resulting in and empty list and charts being rendered when no keywords were found
- Creates `no_keywords.html` for when and empty dict is returned from `extract_total_keywords()`
- Minor update to the README
- Increases the scrape limit from 20 to 50
- Passes the `current_page="list"` value to the list page when rendering from the scrape route