### PR TITLE
Update Dockerfile for deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 FROM python:3.11
 
-# Install Chrome
-RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
-RUN sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list'
-RUN apt-get -y update
-RUN apt-get install -y google-chrome-stable
+# Install Chrome in one RUN command (reduces layers)
+RUN apt-get update && apt-get install -y wget gnupg \
+    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+    && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list' \
+    && apt-get update \
+    && apt-get install -y google-chrome-stable \
+    && rm -rf /var/lib/apt/lists/*
 
 # Install chromedriver
 RUN apt-get install -yqq unzip
@@ -24,5 +26,5 @@ RUN pip install -r ../requirements.txt
 # Copy the entire project
 COPY . ..
 
-# Now run gunicorn from the app directory where scrape.py is located
+# Run gunicorn from the app directory where scrape.py is located
 CMD ["gunicorn", "--bind", "0.0.0.0:10000", "--workers=1", "--timeout=120", "app:app"]


### PR DESCRIPTION
When trying to deploy on Render, `wget` was not running properly when trying to install chrome. In the "install chrome" portion of the docker file, this removes `wget` and the chain of "run" commands and instead uses `apt-get` and a one-liner run command.