### PR TITLE
Update package.json scripts for Biome pre-commit hooks

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,8 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "lint": "biome check .",
-    "lint:fix": "biome check --write ."
+    "lint": "pre-commit run --files $(git ls-files .)",
+    "lint:all": "pre-commit run --all-files"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.3.3",


### PR DESCRIPTION
Biome expects a root level biome.json file. In order to run the frontend related pre-commit hooks (from the root) `"root": false,` needs to be set inside of biome.json when placed in a sub-directory. This disallows running package.json scripts from inside /frontend like `npm run lint` when `lint: npx biome check .` as it will throw an error. This fix is a workaround basically piping the pre-commit script to "lint:" and "lint:all" inside of package.json. Not ideal, but i think the cleanest solution for working around Biome's strict configuration expectations